### PR TITLE
fix for which_sshd

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
         pytest --cov src
         coverage html
     - name: Archive code coverage html report
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: htmlcov/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,3 +44,4 @@ jobs:
       with:
         name: code-coverage-report
         path: htmlcov/
+        overwrite: true

--- a/src/splitcopy/shared.py
+++ b/src/splitcopy/shared.py
@@ -274,14 +274,14 @@ class SplitCopyShared:
         logger.info("entering which_sshd()")
         result, stdout = self.ssh_cmd("sshd -v", exitcode=False, combine=True)
         if self.use_shell:
-            if not re.search(r"OpenSSH_", stdout):
+            if not re.search(r"OpenSSH_|JSSH_", stdout):
                 self.close(err_str="failed to determine remote openssh version")
             output = stdout.split("\n")[2]
         else:
-            if not re.search(r"OpenSSH_", stdout):
+            if not re.search(r"OpenSSH_|JSSH_", stdout):
                 self.close(err_str="failed to determine remote openssh version")
             output = stdout.split("\n")[1]
-        version = re.sub(r"OpenSSH_", "", output)
+        version = re.sub(r"OpenSSH_|JSSH_", "", output)
         sshd_version = float(version[0:3])
         return sshd_version
 

--- a/src/splitcopy/tests/test_paramikoshell.py
+++ b/src/splitcopy/tests/test_paramikoshell.py
@@ -158,6 +158,7 @@ class TestParamikoShell:
             paramikoshell.get_pkey_from_file("EC", "/homes/foo/.ssh/bar")
 
     import paramiko
+    import pytest
     dss_key_available = hasattr(paramiko, "DSSKey")
     @pytest.mark.skipif(not dss_key_available, reason="paramiko.DSSKey not available (removed in paramiko 3.x)")
     def test_get_pkey_from_file_dsa(self, monkeypatch: MonkeyPatch):

--- a/src/splitcopy/tests/test_paramikoshell.py
+++ b/src/splitcopy/tests/test_paramikoshell.py
@@ -157,6 +157,8 @@ class TestParamikoShell:
         with raises(PasswordRequiredException):
             paramikoshell.get_pkey_from_file("EC", "/homes/foo/.ssh/bar")
 
+    dss_key_available = hasattr(paramiko, "DSSKey")
+    @pytest.mark.skipif(not dss_key_available, reason="paramiko.DSSKey not available (removed in paramiko 3.x)")
     def test_get_pkey_from_file_dsa(self, monkeypatch: MonkeyPatch):
         def from_private_key_file(filename):
             return "dsa key"

--- a/src/splitcopy/tests/test_paramikoshell.py
+++ b/src/splitcopy/tests/test_paramikoshell.py
@@ -157,6 +157,7 @@ class TestParamikoShell:
         with raises(PasswordRequiredException):
             paramikoshell.get_pkey_from_file("EC", "/homes/foo/.ssh/bar")
 
+    import paramiko
     dss_key_available = hasattr(paramiko, "DSSKey")
     @pytest.mark.skipif(not dss_key_available, reason="paramiko.DSSKey not available (removed in paramiko 3.x)")
     def test_get_pkey_from_file_dsa(self, monkeypatch: MonkeyPatch):


### PR DESCRIPTION
Fix to handle the ssh version "JSSH_4.1, OpenSSL 1.1.1zb  11"

error “failed to determine remote openssh version”
 "JSSH_4.1, OpenSSL 1.1.1zb  11 Feb 2025"  output. Earlier version uses "OpenSSH_7.5, OpenSSL 1.0.2zi  1 Aug 2023"
